### PR TITLE
New Unit that Wraps XLMMacroDeobfuscator

### DIFF
--- a/refinery/units/formats/office/xlmdeobf.py
+++ b/refinery/units/formats/office/xlmdeobf.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import tempfile
+
+from refinery.units.formats import Unit
+
+
+class XLMMacroDeobfuscator(Unit):
+    """
+    Wrapper around XLMMacroDeobfuscator to decode obfuscated XLM macros
+    """
+
+    def __init__(
+        self,
+        extract_only: Unit.Arg.switch(
+            "-x", help="only extract cells without any emulation"
+        ) = False,
+        sort_formulas: Unit.Arg.switch(
+            "--sort-formulas",
+            help="sort extracted formulas based on their cell address (requires -x)",
+        ) = False,
+        defined_names: Unit.Arg.switch(
+            "--defined-names", help="extract all defined names"
+        ) = False,
+        with_ms_excel: Unit.Arg.switch(
+            "--with-ms-excel", help="use MS Excel to process XLS files"
+        ) = False,
+        start_with_shell: Unit.Arg.switch(
+            "-s", help="open an XLM shell before interpreting the macros in the input"
+        ) = False,
+        day: Unit.Arg(
+            "-d",
+            "--day",
+            type=int,
+            default=-1,
+            action="store",
+            help="Specify the day of month",
+        ) = -1,
+        output_formula_format: Unit.Arg(
+            "--output-formula-format",
+            type=str,
+            default="CELL:[[CELL-ADDR]], [[STATUS]], [[INT-FORMULA]]",
+            action="store",
+            help="Specify the format for output formulas ([[CELL-ADDR]], [[INT-FORMULA]], and [[STATUS]]",
+        ) = "CELL:[[CELL-ADDR]], [[STATUS]], [[INT-FORMULA]]",
+        extract_formula_format: Unit.Arg(
+            "--extract-formula-format",
+            type=str,
+            default="CELL:[[CELL-ADDR]], [[CELL-FORMULA]], [[CELL-VALUE]]",
+            action="store",
+            help="Specify the format for extracted formulas ([[CELL-ADDR]], [[CELL-FORMULA]], and [[CELL-VALUE]]",
+        ) = "CELL:[[CELL-ADDR]], [[CELL-FORMULA]], [[CELL-VALUE]]",
+        no_indent: Unit.Arg.switch(
+            "--no-indent",
+            help="Do not show indent before formulas",
+        ) = False,
+        start_point: Unit.Arg(
+            "--start-point",
+            type=str,
+            default="",
+            action="store",
+            help="Start interpretation from a specific cell address",
+            metavar=("CELL_ADDR"),
+        ) = "",
+        password: Unit.Arg(
+            "-p",
+            "--password",
+            type=str,
+            action="store",
+            default="",
+            help="Password to decrypt the protected document",
+        ) = "",
+        output_level: Unit.Arg(
+            "-o",
+            "--output-level",
+            type=int,
+            action="store",
+            default=0,
+            help="Set the level of details to be shown (0:all commands, 1: commands no jump 2:important commands 3:strings in important commands).",
+        ) = 0,
+        timeout: Unit.Arg(
+            "--timeout",
+            type=int,
+            action="store",
+            default=0,
+            metavar=("N"),
+            help="stop emulation after N seconds (0: not interruption N>0: stop emulation after N seconds)",
+        ) = 0,
+    ):
+        pass
+
+    @Unit.Requires("XLMMacroDeobfuscator", optional=False)
+    def _process_file():
+        from XLMMacroDeobfuscator.deobfuscator import process_file
+
+        return process_file
+
+    def process(self, data: bytearray):
+        with tempfile.NamedTemporaryFile() as nf:
+            nf.write(data)
+            result = self._process_file(
+                file=nf.name,
+                noninteractive=True,
+                return_deobfuscated=True,
+                silent=True,
+                sort_formulas=self.args.sort_formulas,
+                defined_names=self.args.defined_names,
+                with_ms_excel=self.args.with_ms_excel,
+                start_with_shell=self.args.start_with_shell,
+                day=self.args.day,
+                output_formula_format=self.args.output_formula_format,
+                extract_formula_format=self.args.extract_formula_format,
+                no_indent=self.args.no_indent,
+                start_point=self.args.start_point,
+                password=self.args.password,
+                output_level=self.args.output_level,
+                timeout=self.args.timeout,
+            )
+            return "\n".join(result).encode("utf-8")

--- a/refinery/units/formats/office/xlmdeobf.py
+++ b/refinery/units/formats/office/xlmdeobf.py
@@ -2,9 +2,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import tempfile
-
 from refinery.units.formats import Unit
+from refinery.lib.vfs import VirtualFileSystem, VirtualFile
 
 
 class XLMMacroDeobfuscator(Unit):
@@ -78,7 +77,10 @@ class XLMMacroDeobfuscator(Unit):
             type=int,
             action="store",
             default=0,
-            help="Set the level of details to be shown (0:all commands, 1: commands no jump 2:important commands 3:strings in important commands).",
+            help=(
+                "Set the level of details to be shown (0:all commands, 1: commands no jump 2:important "
+                "commands 3:strings in important commands)."
+            ),
         ) = 0,
         timeout: Unit.Arg(
             "--timeout",
@@ -98,10 +100,9 @@ class XLMMacroDeobfuscator(Unit):
         return process_file
 
     def process(self, data: bytearray):
-        with tempfile.NamedTemporaryFile() as nf:
-            nf.write(data)
+        with VirtualFileSystem() as vfs:
             result = self._process_file(
-                file=nf.name,
+                file=VirtualFile(vfs, data),
                 noninteractive=True,
                 return_deobfuscated=True,
                 silent=True,
@@ -118,4 +119,4 @@ class XLMMacroDeobfuscator(Unit):
                 output_level=self.args.output_level,
                 timeout=self.args.timeout,
             )
-            return "\n".join(result).encode("utf-8")
+        return "\n".join(result).encode(self.codec)

--- a/test/units/formats/office/test_xlmdeobf.py
+++ b/test/units/formats/office/test_xlmdeobf.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from ... import TestUnitBase
+
+
+class TestXLMMacroDeobfuscator(TestUnitBase):
+    def test_maldoc(self):
+        data = self.download_sample(
+            "dc44bbfc845fc078cf38b9a3543a32ae1742be8c6320b81cf6cd5a8cee3c696a"
+        )
+        unit = self.load()
+        code = list(data | unit)
+        self.assertIn(b"C:\ProgramData\Ropedjo1.ocx", code[0])


### PR DESCRIPTION
For some Excel files, the unit ``xtvba`` (based on olevba) fails to extract Excel 4.0 macros, while the [XLMMacroDeobfuscator](https://github.com/DissectMalware/XLMMacroDeobfuscator) works ([example](https://malshare.com/sample.php?action=detail&hash=dc44bbfc845fc078cf38b9a3543a32ae1742be8c6320b81cf6cd5a8cee3c696a)) . This module also potentially provides better deobfuscation results due to using an emulator.

The new unit just wraps the ``process_file`` function of `XLMMacroDeobfuscator`. Almost all commandline arguments to XLMMacroDeobfuscator are supported with the same defaults. Exceptions are:

- ``silent``: This is always set to ``true``, so the unit does not print the result to stdout.
- ``return_deobfuscated``: To get the results returned.
- ``noninteractive``: This is set to ``true`` for obvious reasons.

Unfortunately, XLMMacroDeobfuscator has the following limitations that maybe need to be addressed:

1. There is a `print` statement warning about ``pywin32`` which can't be muted.
2. XLMMacroDeobfuscator  only works on files, and I could not get it to work with the virtual file system of binref, so the unit uses ``tempfile`` to write the file to disk.

Maybe it would also make sense to add the XLMMacroDeobfuscator functionality to ``xtvba`` rather than an new unit, but I opted for a new unit because:

1. XLMMacroDeobfuscator works only for XLM, not Macros in general.
2. XLMMacroDeobfuscator has many settings that would clutter `xtvba`
