### PR TITLE
Renamed the XLMMacroDeobfuscator unit class

### DIFF
--- a/refinery/units/formats/office/xlmdeobf.py
+++ b/refinery/units/formats/office/xlmdeobf.py
@@ -6,7 +6,7 @@ from refinery.units.formats import Unit
 from refinery.lib.vfs import VirtualFileSystem, VirtualFile
 
 
-class XLMMacroDeobfuscator(Unit):
+class xlmdeobf(Unit):
     """
     Wrapper around XLMMacroDeobfuscator to decode obfuscated XLM macros
     """


### PR DESCRIPTION
Only after the pull request #12 to add ``xlmdeobf`` had been merged, I noticed that I messed up the name of the class. Instead of naming it after the module (`xlmdeobf`) I named it ``XLMMacroDeobfuscator``. This becomes the name of the command which is very hard to type.

This pull request renames the class to ``xlmdeobf``, so the name reflects the module name. This is consistent with other units that are all named with short lower case names.