### PR TITLE
Adds jq unit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "colorama",
     "defusedxml",
+    "jq",
     "macholib",
     "msgpack>=1.0.0",
     "pefile",

--- a/refinery/units/formats/jq.py
+++ b/refinery/units/formats/jq.py
@@ -1,0 +1,85 @@
+import json
+from json.decoder import WHITESPACE
+from typing import Generator, Any
+
+import jq as _jq
+
+from refinery import Unit, Arg
+
+
+def parse_multiple_json(data: bytes) -> Generator[Any, None, None]:
+    doc = data.decode("utf-8")
+
+    decoder = json.JSONDecoder()
+    i = 0
+    while True:
+        i = WHITESPACE.match(doc, i).end()
+        if i >= len(doc):
+            return
+
+        obj, i = decoder.raw_decode(doc, idx=i)
+        yield obj
+
+
+class jq(Unit):
+    meta_key_json_key = "json_key"
+
+    """
+    This unit is a thin wrapper around the tool `jq`, with some adjustments to fit the binref-principles.
+    Each chunk may contain multiple JSON values, separated by whitespaces. Multiple such values will be
+    joined into a single array per chunk, this works similar to the `--slurp` flag of the upstream jq-cli.
+    If there is only one value, it will not be wrapped in an array.
+    """
+
+    def __init__(self,
+                 raw: Arg.Switch("-r", help="output raw data rather than json-encoded data"),
+                 sort_keys: Arg.Switch("-s", help="sort keys"),
+                 compact: Arg.Switch("-c", help="output compact json, rather than pretty printing"),
+                 explode: Arg.Switch("-e", help="output one chunk per array-item or per object-key"),
+                 filter: Arg(help="jq compatible filter") = b"."):
+        super().__init__(raw=raw, sort_keys=sort_keys, compact=compact, explode=explode, filter=filter)
+
+    def process(self, data: bytearray):
+        if not data:
+            return data
+
+        parsed = list(parse_multiple_json(data))
+        if len(parsed) == 1:
+            parsed = parsed[0]
+
+        for obj in _jq.compile(self.args.filter.decode(self.codec)).input(parsed):
+            yield from self._chunk_and_format_data(obj)
+
+    def _chunk_and_format_data(self, data):
+        if self.args.explode:
+            if isinstance(data, list):
+                yield from (self.format_json(chunk) for chunk in data)
+            elif isinstance(data, dict):
+                yield from self._chunk_and_format_dict(data)
+        else:
+            yield self.format_json(data)
+
+    def _chunk_and_format_dict(self, data: dict):
+        for key, value in data.items():
+            metas = {self.meta_key_json_key: key}
+            yield self.labelled(self.format_json(value), **metas)
+
+    def format_json(self, data) -> bytes:
+        if self.args.raw:
+            return self._format_json_raw(data)
+        else:
+            return self._format_json_dumps(data)
+
+    def _format_json_raw(self, data) -> bytes:
+        if isinstance(data, (list, dict)):
+            # This mimics the behaviour of the upstream jq-cli
+            return self._format_json_dumps(data)
+        return str(data).encode(self.codec)
+
+    def _format_json_dumps(self, data) -> bytes:
+        kwargs = {}
+        if self.args.sort_keys:
+            kwargs["sort_keys"] = True
+        if not self.args.compact:
+            kwargs["indent"] = 4
+        return json.dumps(data, **kwargs).encode(self.codec)

--- a/test/units/formats/test_jq.py
+++ b/test/units/formats/test_jq.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import textwrap
+from json import JSONDecodeError
+
+from refinery.lib.frame import Chunk
+from refinery.units.formats.jq import jq
+from .. import TestUnitBase
+
+
+class TestJQ(TestUnitBase):
+
+    def test_prettify_default(self):
+        document = B'{"foo":{"bar":[0, 1, 2, 3],"baz": true,"b0": "Binary","b1": "Refinery"},"bar": {"bar": {"ef": 0,"eg": 1,"ep": 2}}}'
+
+        pretty_document = textwrap.dedent('''\
+        {
+            "foo": {
+                "bar": [
+                    0,
+                    1,
+                    2,
+                    3
+                ],
+                "baz": true,
+                "b0": "Binary",
+                "b1": "Refinery"
+            },
+            "bar": {
+                "bar": {
+                    "ef": 0,
+                    "eg": 1,
+                    "ep": 2
+                }
+            }
+        }''')
+        unit = self.ldu('jq')
+        self.assertEqual(bytes(document | unit).decode("utf-8"), pretty_document)
+
+    def test_sort_keys(self):
+        document = B'{"key2": "value2", "bar": [1, 2], "key1": "value1"}'
+        compact_document = B'{"bar": [1, 2], "key1": "value1", "key2": "value2"}'
+
+        unit = self.ldu('jq', compact=True, sort_keys=True)
+        self.assertEqual(bytes(document | unit), compact_document)
+
+    def test_compact(self):
+        document = B'{"foo":{"bar":[0, 1, 2, 3],"baz": true,"b0": "Binary","b1": "Refinery"},"bar": {"bar": {"ef": 0,"eg": 1,"ep": 2}}}'
+        compact_document = B'{"foo": {"bar": [0, 1, 2, 3], "baz": true, "b0": "Binary", "b1": "Refinery"}, "bar": {"bar": {"ef": 0, "eg": 1, "ep": 2}}}'
+
+        unit = self.ldu('jq', compact=True)
+        self.assertEqual(bytes(document | unit), compact_document)
+
+    def test_basic_filter(self):
+        document = B'''
+        {"foo":{"bar":["foobar", "barfoo"]}}
+        '''
+
+        unit = self.ldu('jq', filter=".foo.bar[1]")
+        self.assertEqual(bytes(document | unit), B'"barfoo"')
+
+    def test_basic_filter_raw(self):
+        document = B'''
+        {"foo":{"bar":["foobar", "barfoo"]}}
+        '''
+
+        unit = self.ldu('jq', filter=".foo.bar[1]", raw=True)
+        self.assertEqual(bytes(document | unit), B'barfoo')
+
+    def test_multiple_documents(self):
+        document = B'''
+        {"doc1": 1} {"doc2": 2}
+        {"doc3": 3}
+        '''
+
+        unit = self.ldu('jq', compact=True)
+        self.assertEqual(bytes(document | unit), B'[{"doc1": 1}, {"doc2": 2}, {"doc3": 3}]')
+
+    def test_raw_on_dict(self):
+        document = B'''
+        {"foo": {"bar": ["foobar", "barfoo"]}}
+        '''
+
+        unit = self.ldu('jq', compact=True, raw=True)
+        self.assertEqual(bytes(document | unit), B'{"foo": {"bar": ["foobar", "barfoo"]}}')
+
+    def test_explode_list(self):
+        document = B'''
+        [{"doc1": 1}, {"doc2": 2}, {"doc3": 3}]
+        '''
+
+        unit = self.ldu('jq', explode=True, compact=True)
+        chunks = [bytes(chunk) for chunk in document | unit]
+        self.assertEqual(chunks, [B'{"doc1": 1}', B'{"doc2": 2}', B'{"doc3": 3}'])
+
+    def test_explode_dict(self):
+        document = B'''
+        {"key1": "value1", "key2": "value2", "key3": "value3"}
+        '''
+
+        unit = self.ldu('jq', explode=True)
+        chunks_data = [bytes(chunk) for chunk in document | unit]
+        chunks_meta = [dict(chunk.meta.items()) for chunk in document | unit]
+        self.assertEqual(chunks_data, [B'"value1"', B'"value2"', B'"value3"'])
+        self.assertEqual(chunks_meta, [{jq.meta_key_json_key: B'key1'},
+                                       {jq.meta_key_json_key: B'key2'},
+                                       {jq.meta_key_json_key: B'key3'}])
+
+    def test_explode_dict_raw(self):
+        document = B'''
+        {"key1": "value1", "key2": "value2", "key3": "value3"}
+        '''
+
+        unit = self.ldu('jq', explode=True, raw=True)
+        chunks_data = [bytes(chunk) for chunk in document | unit]
+        chunks_meta = [dict(chunk.meta.items()) for chunk in document | unit]
+        self.assertEqual(chunks_data, [B'value1', B'value2', B'value3'])
+        self.assertEqual(chunks_meta, [{jq.meta_key_json_key: B'key1'},
+                                       {jq.meta_key_json_key: B'key2'},
+                                       {jq.meta_key_json_key: B'key3'}])
+
+    def test_empty_input(self):
+        document = B''
+
+        unit = self.ldu('jq')
+        self.assertEqual(bytes(document | unit), B"")
+
+    def test_non_json_input(self):
+        document = B'some other bogus data'
+
+        unit = self.ldu('jq')
+        with self.assertRaises(JSONDecodeError):
+            _ = bytes(document | unit)


### PR DESCRIPTION
As promised, I'm back. ;)

[jq](https://stedolan.github.io/jq/) is a powerful json processor, allowing for filtering and manipulation of json data. This PR adds a thin-ish wrapper for the jq python library, allowing a more seamless integration into the binref workflow.

The main difference to the stock jq-cli is support for chunks. Each input chunk is treated individually. Optionally the processed json data can be split into multiple output chunks via the flag `--explode`. This exploding supports arrays trivially, but can also explode dicts. For each key-value-pair in a dict, one chunk is emitted with the meta variable "json_key" set to the key and the chunk data consisting of the value.

## Things to consider

- This adds the dependency "jq"
- As I implemented it, it has an intentional name-clash with the upstream jq command. This is for multiple reasons: (1) because I use binref in a venv, (2) because there is already a hint in the binref readme about possible name clashes and (3) I struggled to come up with a reasonable alias. If you feel uncomfortable adding an intentional name clash, feel free to suggest alternative names. :)

## Possible future features

Currently, it can only explode, not join. Maybe, if someone needs it, a future update might be to combine multiple input chunks into one output chunk.