### PR TITLE
Add unit for generating ntlm hash

### DIFF
--- a/refinery/units/crypto/hash/password_hashes.py
+++ b/refinery/units/crypto/hash/password_hashes.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Implements password hashing algorithms.
+"""
+import hashlib
+
+from refinery.units.crypto.hash import HashUnit
+
+
+class ntlm(HashUnit):
+    """
+    Returns the Windows NTLM hash of the input.
+    """
+    def _algorithm(self, data: bytes) -> bytes:
+        return hashlib.new('md4', data.decode(self.codec).encode("utf-16le")).digest()

--- a/test/units/crypto/hash/test_password_hashes.py
+++ b/test/units/crypto/hash/test_password_hashes.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from ... import TestUnitBase
+
+
+class TestNTLMHash(TestUnitBase):
+
+    def test_ntlm(self):
+        ntlm = self.ldu('ntlm')
+        self.assertEqual(bytes(B'Binary Refinery' | ntlm), bytes.fromhex('0926451370fb30a8132a4fed78c19ce0'))


### PR DESCRIPTION
Adds a `password_hashes.py` module with an `ntlm` unit for converting the input to an ntlm hash.

Output:
![image](https://user-images.githubusercontent.com/20513519/204478438-b11d217e-3b5d-4cff-8fae-1f50cec77ef3.png)

Compare with online generator:
![image](https://user-images.githubusercontent.com/20513519/204478560-ec8be90e-0559-4039-96cf-f8a471acbcc4.png)

Not 100% sure what the best way to handle the input encoding is, python3 default string encoding is utf-8 so that's what we work with (as we have to decode the bytes to re-encode them as utf-16le), though there's the option to add an argument for different encodings if the input is known to be something else.

Please edit/move if it would be better elsewhere/done in a different way etc!