### PR TITLE
rc5 and rc6: Add --segment-size option for CFB mode

### DIFF
--- a/refinery/units/crypto/cipher/rc5.py
+++ b/refinery/units/crypto/cipher/rc5.py
@@ -116,6 +116,8 @@ class rc5(StandardBlockCipherUnit, cipher=SpecifiedAtRuntime):
     """
     def __init__(
         self, key, iv=b'', padding=None, mode=None, raw=False,
+        segment_size: Arg.Number('-S', '--segment-size',
+            help='Only for CFB: Number of bits into which data is segmented. It must be a multiple of 8.') = 0,
         rounds    : Arg.Number('-k', help='Number of rounds to use, the default is {default}') = 12,
         word_size : Arg.Number('-w', help='The word size in bits, {default} by default.') = 32
     ):
@@ -128,4 +130,4 @@ class rc5(StandardBlockCipherUnit, cipher=SpecifiedAtRuntime):
         self._cipher_object_factory = c = BlockCipherFactory(_R)
         self.blocksize = c.block_size
         self.key_sizes = c.key_size
-        super().__init__(key, iv, padding, mode, raw)
+        super().__init__(key, iv, padding, mode, raw, segment_size)

--- a/refinery/units/crypto/cipher/rc6.py
+++ b/refinery/units/crypto/cipher/rc6.py
@@ -117,6 +117,8 @@ class rc6(StandardBlockCipherUnit, cipher=SpecifiedAtRuntime):
     """
     def __init__(
         self, key, iv=b'', padding=None, mode=None, raw=False,
+        segment_size: Arg.Number('-S', '--segment-size',
+            help='Only for CFB: Number of bits into which data is segmented. It must be a multiple of 8.') = 0,
         rounds    : Arg.Number('-k', help='Number of rounds to use, the default is {default}') = 20,
         word_size : Arg.Number('-w', help='The word size in bits, {default} by default.') = 32
     ):
@@ -129,4 +131,4 @@ class rc6(StandardBlockCipherUnit, cipher=SpecifiedAtRuntime):
         self._cipher_object_factory = c = BlockCipherFactory(_R)
         self.blocksize = c.block_size
         self.key_sizes = c.key_size
-        super().__init__(key, iv, padding, mode, raw)
+        super().__init__(key, iv, padding, mode, raw, segment_size)


### PR DESCRIPTION
rc5 and rc6 commands fail to decrypt ciphertext encrypted by other cryptographic tools such as OpenSSL with CFB mode and vice versa because the commands does not have --segment-size (-S) option to set segment size and the default segment size value 0 (it is set in [refinery/units/crypto/cipher/__init__.py](https://github.com/binref/refinery/blob/master/refinery/units/crypto/cipher/__init__.py)) is incompatible with other cryptograpic tools.

The following examples are executed with Binary Refinery 0.5.9 and OpenSSL 1.1.1t on FreeBSD 13.2-stable (I used FreeBSD this time because OpenSSL 1.1.1f on Ubuntu 20.04.6 LTS does not support RC5). 

Decryption with OFB mode (success):
```sh
$ echo "This is a secret message." | openssl enc -e -rc5-ofb -K 30313233343536373839616263646566 -iv 3031323334353637 | rc5 -m ofb -i 01234567 0123456789abcdef | xxd
00000000: 5468 6973 2069 7320 6120 7365 6372 6574  This is a secret
00000010: 206d 6573 7361 6765 2e0a                  message..
$
```

Decryption with CFB mode without --segment-size option (failure):
```sh
$ echo "This is a secret message." | openssl enc -e -rc5-cfb -K 30313233343536373839616263646566 -iv 3031323334353637 | rc5 -m cfb -i 01234567 0123456789abcdef | xxd
00000000: 540b 5e94 cdd1 316a 61ec 2cc9 a875 9355  T.^...1ja.,..u.U
00000010: 2017 ebfc 5893 3970 2edf                  ...X.9p..
$
```

Decryption with CFB mode and proper segment size value setting (success):
```sh
$ echo "This is a secret message." | openssl enc -e -rc5-cfb -K 30313233343536373839616263646566 -iv 3031323334353637 | rc5 -m cfb -i 01234567 --segment-size 64 0123456789abcdef | xxd
00000000: 5468 6973 2069 7320 6120 7365 6372 6574  This is a secret
00000010: 206d 6573 7361 6765 2e0a                  message..
$
```

The following examples are executed on the same environment above with the ciphertext encrypted with [RC6 Encryption and Decryption Online](https://www.lddgo.net/en/encrypt/rc6) with the following setting (I used the online tool because OpenSSL 1.1.1t on FreeBSD 13.2-stable does not support RC6):
Input Content: This is a secret message.
Mode: OFB or CFB
Padding: nopadding
Password: 0123456789abcdef
IV: 0123456789abcdef
In-Format: string
Out-Format: hex
Charset: UTF-8

Output Result with OFB mode: bf96632c806f49a72e8d1ebed739768934d5b62a1d9c33b310
Output Result with CFB mode: bf96632c806f49a72e8d1ebed7397689034b05da2be0b3f0a7

Decryption with OFB mode (success):
```sh
$ echo bf96632c806f49a72e8d1ebed739768934d5b62a1d9c33b310 | hex | rc6 -m ofb -i 0123456789abcdef 0123456789abcdef | xxd
00000000: 5468 6973 2069 7320 6120 7365 6372 6574  This is a secret
00000010: 206d 6573 7361 6765 2e                    message.
$
```

Decryption with CFB mode without --segment-size option (failure):
```sh
$ echo bf96632c806f49a72e8d1ebed7397689034b05da2be0b3f0a7 | hex | rc6 -m cfb -i 0123456789abcdef 0123456789abcdef | xxd
00000000: 5435 e7fb c7cc 53c8 9fdb 33ff 7c97 3169  T5....S...3.|.1i
00000010: 2032 e504 d53d 5521 f4                    2...=U!.
$
```

Decryption with CFB mode and proper segment size value setting (success):
```sh
$ echo bf96632c806f49a72e8d1ebed7397689034b05da2be0b3f0a7 | hex | rc6 -m cfb -i 0123456789abcdef --segment-size 128 0123456789abcdef | xxd
00000000: 5468 6973 2069 7320 6120 7365 6372 6574  This is a secret
00000010: 206d 6573 7361 6765 2e                    message.
$
```
