### PR TITLE
Fix bugs in 'base' unit that causes the unit to fail for small alphabet

### DIFF
--- a/refinery/units/encoding/base.py
+++ b/refinery/units/encoding/base.py
@@ -98,8 +98,10 @@ class base(Unit):
             defaults = _DEFAULT_ALPHABET[:base]
             if alphabet != defaults:
                 self.log_info('translating input data to a default alphabet for faster conversion')
-                data = data.translate(bytes.maketrans(alphabet, defaults))
-            result = int(data, self.args.base)
+                data_translated = data.translate(bytes.maketrans(alphabet, defaults))
+                result = int(data_translated, base)
+            else:
+                result = int(data, base)
         elif len(alphabet) == 64:
             import base64
             _b64_alphabet = _LARGER_ALPHABETS[64]

--- a/test/units/encoding/test_base.py
+++ b/test/units/encoding/test_base.py
@@ -67,3 +67,9 @@ class TestBaseUnit(TestUnitBase):
         unit = self.load(shuffled)
         data = self.generate_random_buffer(200)
         self.assertEqual(bytes(data | -b85 | map(alphabet, shuffled) | unit), data)
+
+    def test_small_alphabet(self):
+        alphabet = b'abc'
+        data = 'cbac'
+        unit = self.load(alphabet)
+        self.assertEqual(bytes(data | unit), b'A') 


### PR DESCRIPTION
The following pipeline fails in 67b9bdfc79ab85cbaacf59b3df5f15a23ef46a11:

```
⇒ emit cbac | base "abc"   
(20:45:08) failure in base: exception of type TypeError; 'bytes' object cannot be interpreted as an integer
```

The reason is that here
https://github.com/binref/refinery/blob/67b9bdfc79ab85cbaacf59b3df5f15a23ef46a11/refinery/units/encoding/base.py#L102
the value ``self.args.base`` is referenced, which still points to the argument passed to the unit, i.e., the alphabet (``abc``). Instead, the value of ``base`` should be used, which is correctly set to the length of the alphabet (``3`` in the example above).

Furthermore, there is an issue with overwriting the data here https://github.com/binref/refinery/blob/67b9bdfc79ab85cbaacf59b3df5f15a23ef46a11/refinery/units/encoding/base.py#L101

because the original data will later be used here https://github.com/binref/refinery/blob/67b9bdfc79ab85cbaacf59b3df5f15a23ef46a11/refinery/units/encoding/base.py#L126

For the example above, this will throw an additional failure ``failure in base: exception of type ValueError; subsection not found``. The reason is, that the input data ``cbac`` will have been translated to ``2102``, while the alphabet is still ``abc``, and the index ``alphabet.index('a')`` fails.

I solved this issue by creating a copy of the data, but maybe you prefer to translate the alphabet instead (so ``abc`` would become ``012``). Maybe something along the lines of

```Python
trans = bytes.maketrans(alphabet, defaults)
alphabet = alphabet.translate(trans)
data = data.translate(trans)
```

I also created a new case that tests for both these issues.