### PR TITLE
Fixed docstring reference to REFINERY_TERM_SIZE environment variable

### DIFF
--- a/refinery/lib/tools.py
+++ b/refinery/lib/tools.py
@@ -45,7 +45,7 @@ def lookahead(iterator: Iterable[_T]) -> Generator[Tuple[bool, _T], None, None]:
 def get_terminal_size(default=0):
     """
     Returns the size of the currently attached terminal. If the environment variable
-    `REFINERY_TERMSIZE` is set to an integer value, it takes prescedence. If the width
+    `REFINERY_TERM_SIZE` is set to an integer value, it takes prescedence. If the width
     of the terminal cannot be determined of if the width is less than 8 characters,
     the function returns zero.
     """


### PR DESCRIPTION
While trying to use binref in a non-interactive terminal session, I ran into issues with the terminal columns being 0 and causing errors.I saw the `REFINERY_TERMSIZE` environment variable referenced in the `get_terminal_size` method which would fix my issue, however it didn't actually work.

 After looking at the code more in depth, I noticed this is because the correct environment variable is `REFINERY_TERM_SIZE`, which is parsed out here https://github.com/binref/refinery/blob/67b9bdfc79ab85cbaacf59b3df5f15a23ef46a11/refinery/lib/environment.py#L160

This PR is to fix the docstring of the `get_terminal_size` method to reference the correct environment variable spelling.