### PR TITLE
Correct Tuple

### DIFF
--- a/refinery/units/formats/pe/pestrip.py
+++ b/refinery/units/formats/pe/pestrip.py
@@ -196,11 +196,11 @@ class pestrip(OverlayUnit):
                 'PointerToRawData',
             ))
             for attribute in (
-                'CvHeaderOffset'
-                'OffsetIn2Qwords'
-                'OffsetInQwords'
-                'Offset'
-                'OffsetLow'
+                'CvHeaderOffset',
+                'OffsetIn2Qwords',
+                'OffsetInQwords',
+                'Offset',
+                'OffsetLow',
                 'OffsetHigh'
             ):
                 if not hasattr(structure, attribute):


### PR DESCRIPTION
The tuple used the for-loop was missing commas to separate the items. Without the commas, the tuple is read as a string and the `attribute` gets checked against characters in the string. With the commas, each attribute is correctly checked against each item within the tuple.