### PR TITLE
Add SingleFileExtractor Port to BinRef

### DIFF
--- a/refinery/units/formats/pe/dotnet/dnsfx.py
+++ b/refinery/units/formats/pe/dotnet/dnsfx.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import zlib
+from refinery.units.formats import PathExtractorUnit, UnpackResult
+from refinery.lib.dotnet.types import (
+    Box,
+    Byte,
+    StreamReader,
+    StringPrimitive,
+    UInt32,
+    UInt64,
+    ParserEOF
+)
+
+
+class BundleFileEntry():
+    def __init__(self, data, offset, size, compressed_size, ftype, rel_path):
+        self.Name = rel_path
+        self.Data = self.get_data(self.reader(data), offset, size, compressed_size, ftype)
+    
+    def get_data(self, reader, offset, size, compressed_size, ftype):
+        reader.seek(offset)
+
+        if compressed_size:
+            compressed_data = reader.read(compressed_size)
+            return self._decompress(compressed_data)
+            
+        else:
+            return reader.read(size)
+    
+    def reader(self, data):
+        return StreamReader(data)
+    
+    def _decompress(self, data):
+        if data[0] == 0x78 or data[0:2] == B'\x1F\x8B':
+            mode_candidates = [15 | 0x20, -15, 0]
+        else:
+            mode_candidates = [-15, 15 | 0x20, 0]
+        for mode in mode_candidates:
+            try:
+                z = zlib.decompressobj(mode)
+                return z.decompress(data)
+            except zlib.error:
+                pass
+        raise ValueError('could not detect any zlib stream.')
+
+class DotNetSingleFileBundle:
+    """
+    Ported to Python from sfextract .NET project
+    https://github.com/Droppers/SingleFileExtractor/tree/main
+    """
+    def __init__(self, data, pe=None, parse_resources=True):
+        try:
+            self.data = data
+            self.manifest_offset = self._find_bundle_manifest_offset()
+            self.resources = []
+            self._parse_bundle_manifest()
+        except IndexError:
+            if not data: raise
+
+    _bundle_signature = bytes([
+        # 32 bytes represent the bundle signature: SHA-256 for ".net core bundle"
+        0x8b, 0x12, 0x02, 0xb9, 0x6a, 0x61, 0x20, 0x38,
+        0x72, 0x7b, 0x93, 0x02, 0x14, 0xd7, 0xa0, 0x32,
+        0x13, 0xf5, 0xb9, 0xe6, 0xef, 0xae, 0x33, 0x18,
+        0xee, 0x3b, 0x2d, 0xce, 0x24, 0xb3, 0x6a, 0xae
+    ])
+
+    def _find_bundle_manifest_offset(self) -> int:
+        bundle_sig_offset = self.data.find(self._bundle_signature, 0)
+        if bundle_sig_offset < 0:
+            # Didn't find the single file app signature
+            pass
+        return int.from_bytes(self.data[bundle_sig_offset-8:bundle_sig_offset], "little")
+
+    def _parse_bundle_manifest(self):
+        def parse(reader):
+            reader.seek(self.manifest_offset)
+
+            major_version = reader.expect(UInt32)
+            minor_version = reader.expect(UInt32)
+            file_count = reader.expect(UInt32)
+            bundle_hash = reader.expect(StringPrimitive)
+
+            if major_version >= 2:
+                reader.expect(UInt64) # depsOffset
+                reader.expect(UInt64) # depsSize
+                reader.expect(UInt64) # runtimeConfigOffset
+                reader.expect(UInt64) # runtimeConfigSize
+                flags = reader.expect(UInt64) # flags
+
+            for file in range(file_count):
+                try:
+                    offset = reader.expect(UInt64)
+                    size = reader.expect(UInt64)
+                    compressed_size = 0
+
+                    if major_version >= 6:
+                        compressed_size = reader.expect(UInt64)
+
+                    ftype = reader.expect(Byte)
+                    rel_path = reader.expect(StringPrimitive)
+
+                    entry = BundleFileEntry(self.data, offset, size, compressed_size, ftype, rel_path)
+
+                    yield Box(
+                        Name=entry.Name,
+                        Data=entry.Data
+                    )
+                except ParserEOF:
+                    yield Box(
+                        Name='Empty',
+                        Data=B''
+                    )
+        self.files = list(parse(self.reader(self.data)))
+
+    def reader(self, data):
+        return StreamReader(data)
+
+class dnsfx(PathExtractorUnit):
+    """
+    Extract .NET single file application
+    https://github.com/Droppers/SingleFileExtractor/tree/main
+    """        
+
+    def unpack(self, data):
+        bundle = DotNetSingleFileBundle(data)
+
+        for file in bundle.files:
+            yield UnpackResult(file.Name, file.Data)

--- a/refinery/units/formats/pe/dotnet/dnsfx.py
+++ b/refinery/units/formats/pe/dotnet/dnsfx.py
@@ -70,7 +70,7 @@ class DotNetSingleFileBundle:
         bundle_sig_offset = self.data.find(self._bundle_signature, 0)
         if bundle_sig_offset < 0:
             # Didn't find the single file app signature
-            raise IndexError("Can't find valid Bundle Manifest offset. Is this a .NET Bundle?")
+            raise ValueError("Can't find valid Bundle Manifest offset. Is this a .NET Bundle?")
         return int.from_bytes(self.data[bundle_sig_offset-8:bundle_sig_offset], "little")
 
     def _parse_bundle_manifest(self):

--- a/refinery/units/formats/pe/dotnet/dnsfx.py
+++ b/refinery/units/formats/pe/dotnet/dnsfx.py
@@ -70,7 +70,7 @@ class DotNetSingleFileBundle:
         bundle_sig_offset = self.data.find(self._bundle_signature, 0)
         if bundle_sig_offset < 0:
             # Didn't find the single file app signature
-            pass
+            raise IndexError("Can't find valid Bundle Manifest offset. Is this a .NET Bundle?")
         return int.from_bytes(self.data[bundle_sig_offset-8:bundle_sig_offset], "little")
 
     def _parse_bundle_manifest(self):

--- a/test/units/formats/pe/dotnet/test_dnsfx.py
+++ b/test/units/formats/pe/dotnet/test_dnsfx.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from .... import TestUnitBase
+
+
+class TestDotNetSingleFileApplicationExtractor(TestUnitBase):
+
+    def test_compression(self):
+        unit = self.load()
+        data = self.download_sample('34dbeb0b19ae70596a1abd00f57002fbef59f390dec759498298e6e93f252db2')
+        data = unit(data)
+        self.assertTrue(data.startswith(b'7B\x0D\x0A\x20\x20'))
+        self.assertIn(b'Compression.pdb', data)
+
+    def test_no_compression(self):
+        unit = self.load()
+        data = self.download_sample('69f32fe40a58e5051c7616b186ababe7466a9e973713c80689c50aea943674eb')
+        data = unit(data)
+        self.assertTrue(data.startswith(b'7B\x0D\x0A\x20\x20'))
+        self.assertIn(b'Compression.pdb', data)
+

--- a/test/units/formats/pe/dotnet/test_dnsfx.py
+++ b/test/units/formats/pe/dotnet/test_dnsfx.py
@@ -9,13 +9,13 @@ class TestDotNetSingleFileApplicationExtractor(TestUnitBase):
         unit = self.load()
         data = self.download_sample('34dbeb0b19ae70596a1abd00f57002fbef59f390dec759498298e6e93f252db2')
         data = unit(data)
-        self.assertTrue(data.startswith(b'7B\x0D\x0A\x20\x20'))
+        self.assertTrue(data.startswith(b'\x7B\x0D\x0A\x20\x20'))
         self.assertIn(b'Compression.pdb', data)
 
     def test_no_compression(self):
         unit = self.load()
         data = self.download_sample('69f32fe40a58e5051c7616b186ababe7466a9e973713c80689c50aea943674eb')
         data = unit(data)
-        self.assertTrue(data.startswith(b'7B\x0D\x0A\x20\x20'))
+        self.assertTrue(data.startswith(b'\x7B\x0D\x0A\x20\x20'))
         self.assertIn(b'Compression.pdb', data)
 


### PR DESCRIPTION
Hello!

I would like to add support for extracting .NET Bundles:
[https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview)

The test files originate from the same repo that I ported:
[https://github.com/Droppers/SingleFileExtractor/tree/main](https://github.com/Droppers/SingleFileExtractor/tree/main)

Let me know if you nee anything else, and of course if you need to make the code prettier please do so and I'll take note for the next unit =]