### PR TITLE
Fix out of bounds error in qlz

### DIFF
--- a/test/units/compression/test_qlz.py
+++ b/test/units/compression/test_qlz.py
@@ -42,3 +42,8 @@ class TestQLZ(TestUnitBase):
             'E85C2EB0DE82F90241EF586AF7CA4F0E'
         )
         self.assertEqual(data | unit | bytes, goal)
+
+    def test_regression_out_of_bounds(self):
+        data = self.download_sample('b124b9180a61ff302ff29acf212a2d31df4ac747b0d2f03b8be47e2e97d2f52a')
+        goal = '77c7d9094f6fc139d8c00d1746de66c73c7376215cbfadcb1bd1ca66f4b978be'
+        self.assertEqual(data | self.load() | self.ldu('sha256', text=True) | str, goal)


### PR DESCRIPTION
The qlz unit seems to have a small issue which causes an IndexError in some cases. The error occurs during the hashtable update in the following line:
`   fetch = fetch >> 8 & 0xFFFF | destination[hashvalue + 3] << 16`
In some cases the algorithm reaches beyond the borders of what has been written so far to the destination buffer.
Full disclosure: I have no clue how QuickLZ works in detail, so I don't know if my fix is the best possible one. I simply looked at [this implementation](https://github.com/dgryski/go-quicklz/blob/master/quicklz.go) and tried to replicate it. Here the destination buffer is preallocated, so if this "overread" occurs, it simply reads a null-byte. This fixed the bug for me. I have a testcase that I can provide (a compressed XMRIG binary that gets downloaded by some malware), but it is rather large (>5mb) so it probably belongs in the refinery-test-data? If there is anything that needs to be adjusted, let me know :)