### PR TITLE
dsjava: fix json encoding of nested JavaMap

### DIFF
--- a/refinery/units/formats/java/deserialize.py
+++ b/refinery/units/formats/java/deserialize.py
@@ -20,6 +20,21 @@ class JavaEncoder(BytesAsArrayEncoder):
             return True
         return False
 
+    def convert_key(self, key):
+        if isinstance(key, dsjava._javaobj.beans.JavaString):
+            return str(key)
+        return key
+
+    def preprocess(self, obj):
+        if isinstance(obj, dict):
+            # Recursively convert dictionary keys
+            return {self.convert_key(k): self.preprocess(v) for k, v in obj.items()}
+        return obj
+
+    def encode(self, obj):
+        obj = self.preprocess(obj)
+        return super().encode(obj)
+
     def default(self, obj):
         try:
             return super().default(obj)


### PR DESCRIPTION
Hello there, many thanks for maintaining this awesome project.

I stumbled upon the following exception in the `dsjava` unit while trying to deserialize some data:

```
TypeError: keys must be str, int, float, bool or None, not JavaString
```

Turns out the `python-javaobj` package deserializes `java.util.HashMap` objects into dictionaries where the keys can be of type `JavaString`. This normally isn't noticeable for flat dicts thanks to [this piece of code](https://github.com/binref/refinery/blob/9bd4661d21c75eae688404cdb7384164fd8ee7e1/refinery/lib/json.py#L58-L64), but we run into issues with nested dicts.

The issue can be reproduced with the attached sample ([listeners.zip](https://github.com/user-attachments/files/15946620/listeners.zip)) and the following pipeline:

```bash
$ r.ef listeners.zip | r.xt | r.dsjava -vv
```

This PR overrides `encode` and adds a `preprocess` method that recursively traverses dicts and converts any `JavaString` key into a plain `str`.