### PR TITLE
Extend NSItem Equality check

### DIFF
--- a/refinery/units/formats/archive/xtnsis.py
+++ b/refinery/units/formats/archive/xtnsis.py
@@ -425,6 +425,23 @@ class NSItem:
 
     def __str__(self):
         return self.name
+    
+    def __eq__(self, other) -> bool:
+        if not other or not isinstance(other, self.__class__):
+            return False
+        return (
+            self.offset == other.offset
+            and self.mtime == other.mtime
+            and self.is_compressed == other.is_compressed
+            and self.is_uninstaller == other.is_uninstaller
+            and self.attributes == other.attributes
+            and self.size == other.size
+            and self.compressed_size == other.compressed_size
+            and self.estimated_size == other.estimated_size
+            and self.dictionary_size == other.dictionary_size
+            and self.patch_size == other.patch_size
+            and self.path == other.path
+        )
 
 
 class NSHeader(Struct):

--- a/refinery/units/formats/archive/xtnsis.py
+++ b/refinery/units/formats/archive/xtnsis.py
@@ -425,23 +425,6 @@ class NSItem:
 
     def __str__(self):
         return self.name
-    
-    def __eq__(self, other) -> bool:
-        if not other or not isinstance(other, self.__class__):
-            return False
-        return (
-            self.offset == other.offset
-            and self.mtime == other.mtime
-            and self.is_compressed == other.is_compressed
-            and self.is_uninstaller == other.is_uninstaller
-            and self.attributes == other.attributes
-            and self.size == other.size
-            and self.compressed_size == other.compressed_size
-            and self.estimated_size == other.estimated_size
-            and self.dictionary_size == other.dictionary_size
-            and self.patch_size == other.patch_size
-            and self.path == other.path
-        )
 
 
 class NSHeader(Struct):
@@ -610,8 +593,7 @@ class NSHeader(Struct):
 
         items: Dict[(str, int), NSItem] = {}
         for item in self._read_items():
-            if items.setdefault((item.path, item.offset), item) != item:
-                raise ValueError(F'Two different items with the same position {item.offset} and the same path: {item.path}.')
+            items.setdefault((item.path, item.offset), item)
 
         self.items = [items[t] for t in sorted(items.keys())]
 


### PR DESCRIPTION
This suggested improvement originated from a PR request for Debloat's parsing of NSIS files.
In short, this executable (https://www.virustotal.com/gui/file/39d17f33b47863330d407ea0e4b2fe7b676c3708dd00ae65432ad21a1ceef997) cannot be parsed by `xtnsis` due to a duplicate item. The duplicate item is found based off of a duplicate offset. The error is raised because the 2nd item is a different python object even though all other elements are the same. 

With extension of equality, no error is raised. Since the two objects are identical in every way, the `items` dictionary is going to keep the first object.

For more details see
Debloat's PR here: https://github.com/Squiblydoo/debloat/pull/43
See error here: https://github.com/Squiblydoo/debloat/issues/42