### PR TITLE
Add a3x feature for parsing EA05 format in addition to EA06 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 > If a release contains only bugfix, it is marked as a 'bugfix release'.
 > Otherwise, the changelog entries highlight only new or changed functionality.
 
+## Version 0.7.5
+- The a3x unit now is capable of decrypting EA05 formatted scripts, previously only capable of decrypting EA06 formatted scripts.
+
 ## Version 0.7.4
 - The `--join` option of all path extraction units has been improved for producing paths that can always be used for dumping data to disk. This includes units to unpack archives, resources, or other embedded data that can be referenced by a name.
 - The `ef` unit has a new option that specifies whether to follow (directory) symlinks / junctions or not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,11 @@
 > If a release contains only bugfix, it is marked as a 'bugfix release'.
 > Otherwise, the changelog entries highlight only new or changed functionality.
 
-## Version 0.7.5
-- The a3x unit now is capable of decrypting EA05 formatted scripts, previously only capable of decrypting EA06 formatted scripts.
-
 ## Version 0.7.4
 - The `--join` option of all path extraction units has been improved for producing paths that can always be used for dumping data to disk. This includes units to unpack archives, resources, or other embedded data that can be referenced by a name.
 - The `ef` unit has a new option that specifies whether to follow (directory) symlinks / junctions or not.
 - The key scaling method for `autoxor` was adjusted to produce less false positives when scanning for larger keys.
+- The a3x unit now is capable of decrypting EA05 formatted scripts, previously only capable of decrypting EA06 formatted scripts.
 
 ## Version 0.7.3 - bugfix release
 

--- a/refinery/__init__.py
+++ b/refinery/__init__.py
@@ -34,7 +34,7 @@ various `refinery.units.Unit`s can be combined.
 4. `refinery.units`: writing custom units, add command-line arguments, and how to use refinery
    units within Python code.
 """
-__version__ = '0.7.5'
+__version__ = '0.7.3'
 __distribution__ = 'binary-refinery'
 
 from typing import Dict, List, Optional, Type, TypeVar, Iterable

--- a/refinery/__init__.py
+++ b/refinery/__init__.py
@@ -34,7 +34,7 @@ various `refinery.units.Unit`s can be combined.
 4. `refinery.units`: writing custom units, add command-line arguments, and how to use refinery
    units within Python code.
 """
-__version__ = '0.7.3'
+__version__ = '0.7.5'
 __distribution__ = 'binary-refinery'
 
 from typing import Dict, List, Optional, Type, TypeVar, Iterable

--- a/refinery/units/formats/a3x.py
+++ b/refinery/units/formats/a3x.py
@@ -726,7 +726,7 @@ def a3x_decrypt_legacy(data: memoryview, key: int) -> bytearray:
             x ^= t[i + 397]
             t[i] = x
 
-        for i in range(0xe3, 0x18c+0xe3):
+        for i in range(0xe3, 0x18c + 0xe3):
             x = t[i] ^ t[i + 1]
             x &= 0x7FFFFFFE
             x ^= t[i]
@@ -739,9 +739,9 @@ def a3x_decrypt_legacy(data: memoryview, key: int) -> bytearray:
             t[i] = x
 
         x = t[0]
-        y = t[0x18c+0xe3] ^ x
+        y = t[0x18c + 0xe3] ^ x
         y &= 0x7FFFFFFE
-        y ^= t[0x18c+0xe3]
+        y ^= t[0x18c + 0xe3]
         y >>= 1
         if (x % 2 == 1):
             x = 0x9908B0DF

--- a/refinery/units/formats/a3x.py
+++ b/refinery/units/formats/a3x.py
@@ -703,6 +703,7 @@ def a3x_decrypt_current(data: memoryview, key: int) -> bytearray:
 
     return bytearray(_decrypted())
 
+
 def a3x_decrypt_legacy(data: memoryview, key: int) -> bytearray:
     a, b, t = 1, 0, []
 
@@ -714,7 +715,7 @@ def a3x_decrypt_legacy(data: memoryview, key: int) -> bytearray:
     def _refactor_state():
         nonlocal t
         for i in range(0, 0xe3):
-            x = t[i] ^ t[i+1]
+            x = t[i] ^ t[i + 1]
             x &= 0x7FFFFFFE
             x ^= t[i]
             x >>= 1
@@ -747,8 +748,8 @@ def a3x_decrypt_legacy(data: memoryview, key: int) -> bytearray:
         else:
             x = 0
         y ^= x
-        y ^= t[0x18c+0xe3-227]
-        t[0x18c+0xe3] = y
+        y ^= t[0x18c + 0xe3 - 227]
+        t[0x18c + 0xe3] = y
 
     def _decrypted():
         nonlocal a, b, t
@@ -770,6 +771,7 @@ def a3x_decrypt_legacy(data: memoryview, key: int) -> bytearray:
 
     return bytearray(_decrypted())
 
+
 def a3x_decrypt(data: memoryview, key: int, is_current: bool = True) -> bytearray:
     if is_current:
         return a3x_decrypt_current(data, key)
@@ -782,6 +784,7 @@ class A3xType(str, Enum):
     NOEXEC = 'AUTOIT NO CMDEXECUTE'
     AHK_SCRIPT = 'AUTOHOTKEY SCRIPT'
     AHK_WITH_ICON = 'AHK WITH ICON'
+
 
 class A3xEncryptionType():
     KEYS = {
@@ -824,8 +827,8 @@ class A3xReader(StructReader[memoryview]):
         else:
             size = (self.u32() ^ size_key)
             seed += size
-        
-        return a3x_decrypt(self.read_exactly(size), seed, is_current) 
+
+        return a3x_decrypt(self.read_exactly(size), seed, is_current)
 
     def read_encrypted_string(self, size_key, seed, is_current=True):
         if is_current:
@@ -849,7 +852,11 @@ class A3xRecord(Struct, parser=A3xReader):
     def __init__(self, reader: A3xReader, encryption_type: A3xEncryptionType):
         self.magic = reader.read(4)
         self.encryption_type = encryption_type
-        self.type = reader.read_encrypted_string(encryption_type.tag_size, encryption_type.tag, encryption_type.is_current).lstrip('>').rstrip('<')
+        self.type = reader.read_encrypted_string(
+            encryption_type.tag_size,
+            encryption_type.tag,
+            encryption_type.is_current
+        ).lstrip('>').rstrip('<')
         self.src_path = reader.read_encrypted_string(encryption_type.path_size, encryption_type.path, encryption_type.is_current)
         self.is_compressed = bool(reader.u8())
         self.is_encrypted = True

--- a/refinery/units/formats/a3x.py
+++ b/refinery/units/formats/a3x.py
@@ -844,12 +844,9 @@ class A3xReader(StructReader[memoryview]):
 
 
 class A3xRecord(Struct, parser=A3xReader):
-    MAGIC = b'\x6B\x43\xCA\x52'
 
     def __init__(self, reader: A3xReader, encryption_type: A3xEncryptionType):
-        if reader.read(4) != self.MAGIC:
-            pass
-            #raise ValueError('Invalid record header magic.')
+        self.magic = reader.read(4)
         self.encryption_type = encryption_type
         self.type = reader.read_encrypted_string(encryption_type.tag_size, encryption_type.tag, encryption_type.is_current).lstrip('>').rstrip('<')
         self.src_path = reader.read_encrypted_string(encryption_type.path_size, encryption_type.path, encryption_type.is_current)

--- a/refinery/units/formats/a3x.py
+++ b/refinery/units/formats/a3x.py
@@ -844,6 +844,7 @@ class A3xReader(StructReader[memoryview]):
 
 
 class A3xRecord(Struct, parser=A3xReader):
+    MAGIC = b'\x6B\x43\xCA\x52'
 
     def __init__(self, reader: A3xReader, encryption_type: A3xEncryptionType):
         self.magic = reader.read(4)

--- a/test/units/formats/test_a3x.py
+++ b/test/units/formats/test_a3x.py
@@ -6,13 +6,15 @@ from .. import TestUnitBase
 class TestA3X(TestUnitBase):
 
     def test_real_world_01(self):
-        sample = self.download_sample(
+        sample_1 = self.download_sample(
             '3b775e678568cd3d55187443a3f7aae2116b7e9762b3c3879f5e1c6225434b25')
-        taint = sample.replace(
+        sample_2 = self.download_sample(
+            '9b66a8ea0f1c64965b06e7a45afbe56f2d4e6d5ef65f32446defccbebe730813')
+        taint = sample_1.replace(
             b'\xA3\x48\x4B\xBE\x98\x6C\x4A\xA9\x99\x4C\x53\x0A\x86\xD6\x48\x7D',
             b'\xDE\xFA\xCE\xD0\xDE\xFA\xCE\xD0\xDE\xFA\xCE\xD0\xDE\xFA\xCE\xD0'
         )
-        for data in [taint, sample]:
+        for data in [taint, sample_1]:
             out = data | self.load() | {'path': [...]}
             self.assertEqual(len(out), 4)
             for key, value in out.items():
@@ -23,3 +25,11 @@ class TestA3X(TestUnitBase):
             self.assertContains(out['script.au3'], Br'FileInstall("MSWINSCK.OCX", @SYSTEMDIR & "\MSWINSCK.OCX")')
             self.assertContains(out['script.au3'], Br'FileInstall("DrWatson.exe", @SYSTEMDIR & "\1096\DrWatson.exe")')
             self.assertContains(out['script.au3'], b'jan1_milan'b'@yahoo'b'.com')
+
+        out = sample_2 | self.load() | {'path': [...]}
+        self.assertEqual(len(out), 1)
+        for key, value in out.items():
+            self.assertEqual(len(value), 1)
+            out[key], = value
+        self.assertSetEqual(set(out), {'unicode-script.au3'})
+        self.assertContains(out['unicode-script.au3'], '''new ActiveXObject('WScript.Shell').Run'''.encode('utf-16')[2:])


### PR DESCRIPTION
Hey! 

Requesting to add to the a3x unit so that it is able to decrypt resources with the "EA05" header. Currently, the unit is only able to decrypt resources with the "EA06" header. They use different decryption algorithms and seed values, but mostly the same compression algorithm, so I've implemented the cryptography for the additional resource type and a class for the seed values.

I'm sure you will have feedback on how I've implemented the solution, so feel free to modify as needed!

Here is a sample that I ran into in a CTF which caused me to look into this problem:
https://malshare.com/sample.php?action=detail&hash=9b66a8ea0f1c64965b06e7a45afbe56f2d4e6d5ef65f32446defccbebe730813
https://www.virustotal.com/gui/file/9b66a8ea0f1c64965b06e7a45afbe56f2d4e6d5ef65f32446defccbebe730813/detection


