### PR TITLE
Fix argument typing in decompress unit, attempt to fix lzw for small inputs

### DIFF
--- a/refinery/units/compression/decompress.py
+++ b/refinery/units/compression/decompress.py
@@ -44,7 +44,7 @@ class decompress(Unit):
             'To determine whether a decompression algorithm was successful, the '
             'ratio of compressed size to decompressed size may at most be as large '
             'as this number, a floating point value R; default value is {default}.')
-        ) = 1,
+        ) = 1.0,
         min_ratio: Arg('-n', metavar='R', help=(
             'Require that compression ratios must be at least as large as R. This '
             'is a "too good to be true" heuristic against algorithms like lznt1 '

--- a/refinery/units/compression/lzw.py
+++ b/refinery/units/compression/lzw.py
@@ -68,11 +68,7 @@ class lzw(Unit):
             ibuf = ibuf[posbits >> 3:]
             insize = len(ibuf)
             posbits = 0
-
-            if insize < LZW.EXTRA:
-                inbits = (insize - insize % n_bits) << 3
-            else:
-                inbits = (insize << 3) - (n_bits - 1)
+            inbits = (insize << 3) - (n_bits - 1)
 
             while inbits > posbits:
                 if free_entry > maxcode:

--- a/test/units/compression/test_lzw.py
+++ b/test/units/compression/test_lzw.py
@@ -14,3 +14,18 @@ class TestLZW(TestUnitBase):
         L = self.load_pipeline
         test = next(data | L('xt7z forth.tap | xtmagtape [| pick 1 ]| lzw'))
         self.assertIn(secret, test)
+
+    def test_really_small_input(self):
+        data = bytes.fromhex("1F9D9061C48C01")
+        test = data | self.load() | ...
+        self.assertEqual(b"abc", test)
+
+    def test_slighly_larger_input(self):
+        data = bytes.fromhex(
+            "1F9D9041840C2152C4C8112449942C61D2C4C9132851A44CA152C5CA152C5"
+            "9B4041C58F060C2850D1F469C58F162C68D040D2254C8D0214489142D62D4"
+            "2830A54796215F929479B266C795205D8E8C69528B02")
+        test = data | self.load() | ...
+        self.assertEqual((b"ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                          b"ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                          b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\n"), test)


### PR DESCRIPTION
Hello!

I ran into a really weird edge case with LZW compression the other day. It seems that sufficiently small inputs "compress" to an inflated size, and this causes some weird interactions with `decompress` and the current iteration of `lzw`. I think the small-input problem is a problem with most compression algorithms for small enough inputs, but I don't think `decompress` is worth changing to fit this edge case. I did attempt to fix the issue in the `lzw` unit however so that it properly decompresses small inputs. I also changed the implicit typing of `max-ratio` argument in `decompress` so that it can actually accept a float.

Lines 71-75 in the origin look to set the last chunk size to a different value based on if the chunk is less than 0x40 bytes. I'm not sure under what circumstances this would be necessary though. I looked through some other implementations and couldn't find a 1-1 representation of what `LZW.Extra` is for. If this turns out to be necessary for your implementation let me know.

My proposal is to remove the if-else statement there and just keep the else condition. I've tested on inputs 1-byte to 1MB and they decompress as expected with this change.