### PR TITLE
Add maru hash

### DIFF
--- a/refinery/lib/maru.py
+++ b/refinery/lib/maru.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Maru hash implementation; originally written by Odzhan. This implementation matches the implementation in Donut.
+Maru hash implementation; it matches the C implementation found in Donut.
 """
 from ctypes import (
     Array,

--- a/refinery/lib/maru.py
+++ b/refinery/lib/maru.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Maru hash implementation; originally written by Odzhan. This implementation matches the implementation in Donut.
+"""
+from ctypes import (
+    Array,
+    Union,
+    c_uint8,
+    c_uint32,
+)
+
+from refinery.lib.speck import (
+    Speck64128KeySchedule,
+    speck_encrypt32,
+)
+
+
+MARU_MAX_STR = 64
+MARU_BLK_LEN = 16
+MARU_HASH_LEN = 8
+
+
+class uint8_array(Array):
+    _type_ = c_uint8
+    _length_ = MARU_BLK_LEN
+
+
+class uint32_array(Array):
+    _type_ = c_uint32
+    _length_ = MARU_BLK_LEN // 4
+
+
+class m_type(Union):
+    _fields_ = ("b", uint8_array), ("w", uint32_array)
+
+
+def swap_dwords(value: int) -> int:
+    return (value & 0xFFFFFFFF) << 32 | (value & 0xFFFFFFFF00000000) >> 32
+
+
+def speck_operation(v: bytearray, m: bytearray) -> int:
+    rk = Speck64128KeySchedule(m)
+    h_bytes = speck_encrypt32(v, rk, 27)
+    h_int = int.from_bytes(h_bytes, "little")
+    h_swapped = swap_dwords(h_int)
+    return h_swapped
+
+
+def maru32(value: bytes, seed: int) -> int:
+    m = m_type()
+    h = seed
+    input_length = len(value)
+    idx = 0
+    length = 0
+    end = False
+    while not end:
+        if length == input_length or length == MARU_MAX_STR:
+            m.b[idx:] = (0,) * (MARU_BLK_LEN - idx)
+            m.b[idx] = 0x80
+            if idx >= MARU_BLK_LEN - 4:
+                h_swapped = swap_dwords(h)
+                h_bytes = h_swapped.to_bytes(8, "little")
+                h ^= speck_operation(h_bytes, bytes(m.b))
+                m.b[:] = (0,) * MARU_BLK_LEN
+            m.w[(MARU_BLK_LEN // 4) - 1] = length * 8
+            idx = MARU_BLK_LEN
+            end = True
+        else:
+            m.b[idx] = value[length]
+            length += 1
+            idx += 1
+        if idx == MARU_BLK_LEN:
+            h_swapped = swap_dwords(h)
+            h_bytes = h_swapped.to_bytes(8, "little")
+            h ^= speck_operation(h_bytes, bytes(m.b))
+            idx = 0
+    return h
+
+
+def maru32digest(value: bytes, seed: int) -> bytes:
+    return maru32(value, seed).to_bytes(8, 'big')

--- a/refinery/units/crypto/hash/maru.py
+++ b/refinery/units/crypto/hash/maru.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from refinery.lib.maru import maru32digest
+from refinery.units.crypto.hash import HashUnit, Arg
+
+
+class MaruHash(HashUnit, abstract=True):
+    def __init__(self, seed: Arg.Number(help='optional seed value') = 0, text=False):
+        super().__init__(seed=seed, text=text)
+
+
+class maru(MaruHash):
+    """
+    Returns the 64bit maru hash of the input data.
+    """
+    def _algorithm(self, data: bytes) -> bytes:
+        return maru32digest(data, self.args.seed)

--- a/test/units/crypto/hash/test_maru.py
+++ b/test/units/crypto/hash/test_maru.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from ... import TestUnitBase
+from refinery.lib.maru import maru32
+
+
+class TestMaruHash(TestUnitBase):
+
+    def test_maru32_short(self):
+        self.assertEqual(maru32(b"C6XCYXF9F", seed=0x454e028b8c6fa548), 0x80d4b6324a24ceb6)
+
+    def test_maru32_long(self):
+        d = maru32(b'HF6FM9RMT3NPMR37TX3FPTFYRFNXTMHWTF7WN94YNP4TMP3FNHM3N9F', 0x454e028b8c6fa548)
+        self.assertEqual(d, 0x30CEBE63BE4E30F1)


### PR DESCRIPTION
This commits add support for the maru hash used by the Donut loader. It uses the previously implemented SPECK cipher.