### PR TITLE
Adding support for Ascii85 encoding and decoding in the b85 unit

### DIFF
--- a/refinery/units/encoding/b85.py
+++ b/refinery/units/encoding/b85.py
@@ -3,19 +3,31 @@
 import base64
 import re
 
-from refinery.units import Unit
+from refinery.units import Arg, Unit
 
 
 class b85(Unit):
     """
     Base85 encoding and decoding.
+    Also supports Ascii85, a slightly different variant of the same encoding.
     """
+    def __init__(
+            self,
+            ascii: Arg.Switch('-a', help='Use Ascii85 instead of Base85.') = False,
+    ):
+        self.ascii = ascii
+        super().__init__()
+
     def reverse(self, data):
+        if self.ascii:
+            return base64.a85encode(data)
         return base64.b85encode(data)
 
     def process(self, data):
         if re.search(BR'\s', data) is not None:
             data = re.sub(BR'\s+', B'', data)
+        if self.ascii:
+            return base64.a85decode(data)
         return base64.b85decode(data)
 
     @classmethod

--- a/test/units/encoding/test_b85.py
+++ b/test/units/encoding/test_b85.py
@@ -3,7 +3,7 @@
 from .. import TestUnitBase
 from ..compression import KADATH1
 
-from base64 import b85encode
+from base64 import b85encode, a85encode
 
 
 class TestBase85(TestUnitBase):
@@ -12,4 +12,16 @@ class TestBase85(TestUnitBase):
         goal = KADATH1.rstrip('\0').encode('latin1')
         data = b85encode(goal)
         data = data | self.ldu('chop', 60) | bytes
+        self.assertEqual(data | unit | bytes, goal)
+    
+    def test_basic_base85_encoding(self):
+        unit = self.load()
+        goal = b"SUFFICIENTLY LONG STRING FOR REFINERY b85"
+        data = b85encode(goal)
+
+        self.assertEqual(data | unit | bytes, goal)
+    def test_basic_ascii85_encoding(self):
+        unit = self.load("-a")
+        goal = b"SUFFICIENTLY LONG STRING FOR REFINERY b85"
+        data = a85encode(goal)
         self.assertEqual(data | unit | bytes, goal)


### PR DESCRIPTION
Hey!

PR to add support for Ascii85 encoding/decoding to the `b85` unit using the `-a` switch. I opted to keep it under the Base85 unit since these are both Base85 encoding schemes, just different alphabets. The "main" alphabet for Base85 I think is actually Ascii85, but python's `b85encode` implementation uses a different alphabet for a reason I did not care to deeply research.

Explanation: https://stackoverflow.com/questions/34969947/what-is-the-difference-between-a85encode-and-b85encode