### PR TITLE
Adding support for sqlite3 queries

### DIFF
--- a/refinery/units/formats/sqlite.py
+++ b/refinery/units/formats/sqlite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+
 from refinery.lib.types import Param
 from refinery.units import Arg, Unit
 
@@ -17,7 +18,7 @@ class sqlite(Unit):
     def __init__(
         self,
         query: Param[
-            str, Arg.String("-q", help="The SQL query to execute.")
+            str, Arg.String("query", help="The SQL query to execute.")
         ] = "SELECT * FROM sqlite_master WHERE type='table';",
     ):
         super().__init__(query=query)


### PR DESCRIPTION
As a long-time user of refinery, I've been meaning to make a unit for sqlite queries, primarily to throw into pipelines for quick wins when triaging systems where compromise likely originated from malvertisement or similar brower-based campaigns, or for web-based exfiltration or tool staging. 

Recently, I also came across a pretty old [revshell which uses google translate as a proxy](https://github.com/mthbernardes/GTRS) - this pushed me to finally make the unit since I found this use-case to be especially satisfying with refinery pipelines (which also makes for a cool demo screenshot).

<img width="1214" height="443" alt="Screenshot 2025-10-22 010135" src="https://github.com/user-attachments/assets/4f17b1c5-9a80-4446-890b-4fb296c3b253" />

As shown above, the unit will extract rows as JSON, and when the unit is ran against an input without supplying it a query, it returns metadata for all tables within the database 😄 
